### PR TITLE
Support for Composer, PHPUnit and Travis-CI

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+
+.travis.yml export-ignore
+phpunit.xml.dist export-ignore
+
+/tests export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+# Ignore generated docs
+docs/
+
+# Ignore composer files
+vendor
+
+# Ignore IDE specific files
+## PHPStorm
+.idea
+
+## Eclipse
+.settings
+.project
+.buildpath
+
+/build
+
+/phpunit.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: php
+
+php:
+  - 5.4
+  - 5.5
+  - 5.6
+  - hhvm
+  - hhvm-nightly
+  
+matrix:
+  allow_failures:
+    - php: hhvm
+    - php: hhvm-nightly
+
+install: composer install
+
+script: phpunit --configuration phpunit.xml.dist

--- a/Dipper.php
+++ b/Dipper.php
@@ -575,15 +575,22 @@ class Dipper
 		if ($value === '' || is_null($value) || $value === 'null' || $value === '~') {
 			// this is empty or a null value!
 			return '';
-		} elseif (is_array($value)) {
+		} elseif (is_array($value) || is_object($value)) {
 			// this is an array!
 			$output = array();
 
-			// but is this a list or a map?
-			if (array_keys($value) === range(0, count($value) - 1)) {
+			if (is_object($value)) {
+				// convert object to array - it is a map
+				$value = get_object_vars($value);
+				$isList = false;
+			} else {
+				// but is this a list or a map?
+				$isList = array_keys($value) === range(0, count($value) - 1);
+			}
+			if ($isList) {
 				// this is a list!
 				foreach ($value as $subvalue) {
-					if (is_array($subvalue)) {
+					if (is_array($subvalue) || is_object($subvalue)) {
 						$output[] = "-\n" . self::build($subvalue, $depth + 1);
 					} else {
 						$output[] = "- " . self::build($subvalue, $depth + 1);
@@ -592,7 +599,7 @@ class Dipper
 			} else {
 				// this is a map!
 				foreach ($value as $key => $subvalue) {
-					if (is_array($subvalue)) {
+					if (is_array($subvalue) || is_object($subvalue)) {
 						$output[] = $key . ":\n" . self::build($subvalue, $depth + 1);
 					} else {
 						$output[] = $key . ": " . self::build($subvalue, $depth + 1);

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,24 @@
+{
+    "name": "secondparty/dipper",
+    "type": "library",
+    "description": "Fast parser for the more commonly-used subset of YAML’s v1.0 and v1.2",
+    "keywords": ["yaml", "parser"],
+    "license": "BSD-3-Clause",
+    "homepage": "https://github.com/secondparty/dipper",
+    "authors": [
+        {
+            "name" : "Fred LeBlanc",
+            "email" : "fred@fredhq.com"
+        }
+    ],
+    "require": {
+    },
+    "suggest": {
+      "ext-syck": "YAML parsing extension for PHP"
+    },
+    "autoload": {
+        "psr-4": {
+            "secondparty\\Dipper\\": "."
+        }
+    }
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         syntaxCheck="false">
+  <testsuites>
+    <testsuite name="Dipper">
+      <directory suffix="Test.php">tests</directory>
+    </testsuite>
+  </testsuites>
+  <filter>
+    <whitelist addUncoveredFilesFromWhitelist="true">
+      <directory suffix=".php">.</directory>
+    </whitelist>
+    <blacklist>
+      <directory suffix=".php">tests</directory>
+    </blacklist>
+  </filter>
+</phpunit>

--- a/tests/DipperTest.php
+++ b/tests/DipperTest.php
@@ -276,4 +276,59 @@ EXPECTED;
 		$this->assertCount(2, $this->parsed['deep_nest_list_shortcut']['first']['second']['third']['fourth']['fifth']);
 		$this->assertEquals('two', $this->parsed['deep_nest_list_shortcut']['first']['second']['third']['fourth']['fifth'][1]);
 	}
+
+  public function testArrayToMap() {
+    $map = [
+      'one' => 'first',
+      'two' => 'second'
+    ];
+    $this->assertEquals(
+      "---\n".
+      "one: first\n".
+      "two: second",
+      \secondparty\Dipper\Dipper::make($map)
+    );
+  }
+
+  public function testNestedArrayToMap() {
+    $map = [
+      'nested' => [
+        'one' => 'first',
+        'two' => 'second'
+      ]
+    ];
+    $this->assertEquals(
+      "---\n".
+      "nested:\n".
+      "  one: first\n".
+      "  two: second",
+      \secondparty\Dipper\Dipper::make($map)
+    );
+  }
+
+  public function testObjectToMap() {
+    $map = new stdClass();
+    $map->one = 'first';
+    $map->two = 'second';
+    $this->assertEquals(
+      "---\n".
+      "one: first\n".
+      "two: second",
+      \secondparty\Dipper\Dipper::make($map)
+    );
+  }
+
+  public function testNestedObjectToMap() {
+    $map = new stdClass();
+    $map->nested = new stdClass();
+    $map->nested->one = 'first';
+    $map->nested->two = 'second';
+    $this->assertEquals(
+      "---\n".
+      "nested:\n".
+      "  one: first\n".
+      "  two: second",
+      \secondparty\Dipper\Dipper::make($map)
+    );
+  }
 }

--- a/tests/DipperTest.php
+++ b/tests/DipperTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // require
-require_once realpath(__DIR__ . '/../Dipper.php');
+require_once realpath(__DIR__ . '/../vendor/autoload.php');
 
 class DipperTest extends PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
The pull requests adds support for Composer and the Composer autoloader without moving the Dipper.php. Projects currently using Dipper will not have to change their source. The test class is changed to use the autoloader.

It adds a .gitproperties that configures the generated archives (ignore development files).

Additionally configuration for PHPUnit and Travis-CI where added.