### PR TITLE
Support for Composer, PHPUnit and Travis-CI

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+
+.travis.yml export-ignore
+phpunit.xml.dist export-ignore
+
+/tests export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+# Ignore generated docs
+docs/
+
+# Ignore composer files
+vendor
+
+# Ignore IDE specific files
+## PHPStorm
+.idea
+
+## Eclipse
+.settings
+.project
+.buildpath
+
+/build
+
+/phpunit.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: php
+
+php:
+  - 5.4
+  - 5.5
+  - 5.6
+  - hhvm
+  - hhvm-nightly
+  
+matrix:
+  allow_failures:
+    - php: hhvm
+    - php: hhvm-nightly
+
+install: composer install
+
+script: phpunit --configuration phpunit.xml.dist

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,24 @@
+{
+    "name": "secondparty/dipper",
+    "type": "library",
+    "description": "Fast parser for the more commonly-used subset of YAML’s v1.0 and v1.2",
+    "keywords": ["yaml", "parser"],
+    "license": "BSD-3-Clause",
+    "homepage": "https://github.com/secondparty/dipper",
+    "authors": [
+        {
+            "name" : "Fred LeBlanc",
+            "email" : "fred@fredhq.com"
+        }
+    ],
+    "require": {
+    },
+    "suggest": {
+      "ext-syck": "YAML parsing extension for PHP"
+    },
+    "autoload": {
+        "psr-4": {
+            "secondparty\\Dipper\\": "."
+        }
+    }
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         syntaxCheck="false">
+  <testsuites>
+    <testsuite name="Dipper">
+      <directory suffix="Test.php">tests</directory>
+    </testsuite>
+  </testsuites>
+  <filter>
+    <whitelist addUncoveredFilesFromWhitelist="true">
+      <directory suffix=".php">.</directory>
+    </whitelist>
+    <blacklist>
+      <directory suffix=".php">tests</directory>
+    </blacklist>
+  </filter>
+</phpunit>

--- a/tests/DipperTest.php
+++ b/tests/DipperTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // require
-require_once realpath(__DIR__ . '/../Dipper.php');
+require_once realpath(__DIR__ . '/../vendor/autoload.php');
 
 class DipperTest extends PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
Second try, separated the commit into a branch :-)

The pull requests adds support for Composer and the Composer autoloader without moving the Dipper.php. Projects currently using Dipper will not have to change their source. The test class is changed to use the autoloader.

It adds a .gitproperties that configures the generated archives (ignore development files).

Additionally configuration for PHPUnit and Travis-CI where added.

Travis-CI: https://travis-ci.org/FluentDOM/dipper/builds/49648015