### PR TITLE
Refactor tests, stdClass support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,13 @@ php:
   - 5.5
   - 5.6
   - 7.0
+  - 7.1
+  - nightly
   - hhvm
   
 matrix:
   allow_failures:
+    - php: nightly
     - php: hhvm
 
 install: composer install

--- a/Dipper.php
+++ b/Dipper.php
@@ -610,6 +610,7 @@ class Dipper
 	 */
 	private static function build($value, $depth=0)
 	{
+	  $value = self::prepareValue($value);
 		// what type of thing is $value?
 		if ($value === '' || is_null($value) || $value === 'null' || $value === '~') {
 			// this is empty or a null value!
@@ -626,6 +627,7 @@ class Dipper
 			if (array_keys($value) === range(0, count($value) - 1)) {
 				// this is a list!
 				foreach ($value as $subvalue) {
+				  $subvalue = self::prepareValue($subvalue);
 					$result = self::build($subvalue, $depth + 1);
 					if (is_array($subvalue)) {
 						$output[] = "-\n" . $result;
@@ -636,6 +638,7 @@ class Dipper
 			} else {
 				// this is a map!
 				foreach ($value as $key => $subvalue) {
+          $subvalue = self::prepareValue($subvalue);
 					$result = self::build($subvalue, $depth + 1);
 					if (is_array($subvalue) && count($subvalue)) {
 						$output[] = $key . ":\n" . $result;
@@ -733,4 +736,17 @@ class Dipper
 		// this is a small, no-quotes-needed string!
 		return trim($value);
 	}
+
+  /**
+   * Prepare value for serialization, cast stdClass to array.
+   *
+   * @param mixed $value
+   * @return mixed
+   */
+	private static function prepareValue($value) {
+	  if ($value instanceof \stdClass) {
+	    return (array)$value;
+    }
+    return $value;
+  }
 }

--- a/tests/DipperTest.php
+++ b/tests/DipperTest.php
@@ -8,350 +8,38 @@ class DipperTest extends PHPUnit_Framework_TestCase
 {
 	protected $parsed;
 	protected $alternate_parsed;
-	
+
 	protected function setUp()
 	{
 		// create YAML to use
-		$yaml = <<<YAML
-working: true
-
-string: this is a string
-single_quoted_string: 'this is a single-quoted string'
-double_quoted_string: "this is a double-quoted string"
-non_full_quoted_string: "\"This is\" some text in a string"
-string_with_single_quote: this's a string with a single quote
-string_with_colon: 'this is a string: containing a colon'
-string_with_comma: F j, Y
-quoted_number: "120"
-quoted_true: "true"
-quoted_false: "false"
-url: http://something.com
-
-literal_scalar: |
-  This is a scalar
-  that will preserve
-  its line breaks.
-
-folding_scalar: >
-  This is a scalar
-  that will fold up
-  line breaks.
-
-literal_scalar_with_markdown: |
-  ### Testing
-  This should be OK and not a comment
-  
-  ### Another
-  Testing again
-
-integer: 42            # becomes an integer 
-float: -12.12          # becomes a float
-octal: 0755            # YAML 1.0-style, becomes an integer, converted from octal
-also_octal: 0o755      # YAML 1.2-style, becomes an integer, converted from octal
-hex: 0xff              # becomes an integer, converted from hexadecimal
-infinite: (inf)        # YAML 1.0-style, becomes INF, PHP constant for infinity
-minus_inf: (-inf)      # YAML 1.0-style, becomes -INF, PHP constant for negative infinity
-also_nan: (NaN)        # YAML 1.0-style, becomes NAN, PHP constant for not-a-number
-also_infinity: .inf    # YAML 1.2-style, becomes INF, PHP constant for infinity
-also_minus_inf: -.inf  # YAML 1.2-style, becomes -INF, PHP constant for negative infinity
-not_a_number: .NaN     # YAML 1.2-style, becomes NAN, PHP constant for not-a-number
-
-bool_true: true        # becomes true (as a boolean)
-bool_false: false      # becomes false (as a boolean)
-null_value: null       # becomes a PHP null value
-shorthand_null: ~      # becomes a PHP null value
-empty_value:           # becomes a PHP null value
-
-regular_list:
-  - first item
-  - second item
-  - third item
-
-shorthand_list: [ first item, second item, third item ]
-shorthand_quoted_list: [ 'one', 'two', 'three' ]
-empty_shorthand_list: []
-
-map:
-  one: first
-  two: second
-  
-shorthand_map: { one: first, two: second, third: "this, the thing" }
-
-nested_map_lists:
-  - name: Bill
-    job: Architect
-  - name: Fred
-    job: Designer
-  - name: Willie
-    job: Builder
-    
-nested_shorthand_maps:
-  - { name: Bill, job: Architect }
-  - { name: Fred, job: Designer }
-  - { name: Willie, job: Builder }
-		
-nested_maps:
-  first:
-    name: Bill
-    job: Architect
-  second:
-    name: Fred
-    job: Designer
-  third:
-    name: Willie
-    job: Builder
-    
-deep_nest_list_shortcut:
-  first:
-    second:
-      third:
-        fourth:
-          fifth: [ one, two ]
-
-sample_test:
-  - name: name
-    label: Name
-    type: text
-    validate:
-      required: true
-
-YAML;
-		
-		$alternate_yaml = <<<YAML
-working: true
-
-string: this is a string
-single_quoted_string: 'this is a single-quoted string'
-double_quoted_string: "this is a double-quoted string"
-non_full_quoted_string: "\"This is\" some text in a string"
-string_with_single_quote: this's a string with a single quote
-string_with_colon: 'this is a string: containing a colon'
-string_with_comma: F j, Y
-quoted_number: "120"
-quoted_true: "true"
-quoted_false: "false"
-url: http://something.com
-
-literal_scalar: |
-  This is a scalar
-  that will preserve
-  its line breaks.
-
-folding_scalar: >
-  This is a scalar
-  that will fold up
-  line breaks.
-
-literal_scalar_with_markdown: |
-  ### Testing
-  This should be OK and not a comment
-  
-  ### Another
-  Testing again
-
-integer: 42            # becomes an integer 
-float: -12.12          # becomes a float
-octal: 0755            # YAML 1.0-style, becomes an integer, converted from octal
-also_octal: 0o755      # YAML 1.2-style, becomes an integer, converted from octal
-hex: 0xff              # becomes an integer, converted from hexadecimal
-infinite: (inf)        # YAML 1.0-style, becomes INF, PHP constant for infinity
-minus_inf: (-inf)      # YAML 1.0-style, becomes -INF, PHP constant for negative infinity
-also_nan: (NaN)        # YAML 1.0-style, becomes NAN, PHP constant for not-a-number
-also_infinity: .inf    # YAML 1.2-style, becomes INF, PHP constant for infinity
-also_minus_inf: -.inf  # YAML 1.2-style, becomes -INF, PHP constant for negative infinity
-not_a_number: .NaN     # YAML 1.2-style, becomes NAN, PHP constant for not-a-number
-
-bool_true: true        # becomes true (as a boolean)
-bool_false: false      # becomes false (as a boolean)
-null_value: null       # becomes a PHP null value
-shorthand_null: ~      # becomes a PHP null value
-empty_value:           # becomes a PHP null value
-
-regular_list:
-  - first item
-  - second item
-  - third item
-
-shorthand_list: [ first item, second item, third item ]
-shorthand_quoted_list: [ 'one', 'two', 'three' ]
-empty_shorthand_list: []
-
-map:
-  one: first
-  two: second
-  
-shorthand_map: { one: first, two: second, third: "this, the thing" }
-
-nested_map_lists:
-  - name: Bill
-    job: Architect
-  - name: Fred
-    job: Designer
-  - name: Willie
-    job: Builder
-    
-nested_shorthand_maps:
-  - { name: Bill, job: Architect }
-  - { name: Fred, job: Designer }
-  - { name: Willie, job: Builder }
-		
-nested_maps:
-  first:
-    name: Bill
-    job: Architect
-  second:
-    name: Fred
-    job: Designer
-  third:
-    name: Willie
-    job: Builder
-    
-deep_nest_list_shortcut:
-  first:
-    second:
-      third:
-        fourth:
-          fifth: [ one, two ]
-
-sample_test:
-  - name: name
-    label: Name
-    type: text
-    validate:
-      required: true
-
-YAML;
+		$yaml = file_get_contents(__DIR__.'/TestData/example-lf.yaml');
+		$alternate_yaml = file_get_contents(__DIR__.'/TestData/example-crlf.yaml');
 
 		$this->parsed = \secondparty\Dipper\Dipper::parse($yaml);
 		$this->alternate_parsed = \secondparty\Dipper\Dipper::parse($alternate_yaml);
 	}
-	
-	
+
+
 	// ensure that something was even parsed
 	public function testParse()
 	{
 		$this->assertArrayHasKey('working', $this->parsed);
-		
+
 		// parsed is the file with `\n` new-lines,
 		// alternate_parsed uses `\r\n` new-lines,
 		// testing that these both parsed correctly
 		$this->assertEquals(md5(serialize($this->parsed)), md5(serialize($this->alternate_parsed)));
 	}
-	
+
 	public function testMake()
 	{
+
 		$yaml = \secondparty\Dipper\Dipper::make($this->parsed);
-		$expected = <<<EXPECTED
----
-working: true
-string: this is a string
-single_quoted_string: this is a single-quoted string
-double_quoted_string: this is a double-quoted string
-non_full_quoted_string: "\"This is\" some text in a string"
-string_with_single_quote: this's a string with a single quote
-string_with_colon: 'this is a string: containing a colon'
-string_with_comma: F j, Y
-quoted_number: '120'
-quoted_true: 'true'
-quoted_false: 'false'
-url: 'http://something.com'
-literal_scalar: |
-  This is a scalar
-  that will preserve
-  its line breaks.
-folding_scalar: This is a scalar that will fold up line breaks.
-literal_scalar_with_markdown: |
-  ### Testing
-  This should be OK and not a comment
-  
-  ### Another
-  Testing again
-integer: 42
-float: -12.12
-octal: 493
-also_octal: 493
-hex: 255
-infinite: (inf)
-minus_inf: (-inf)
-also_nan: (NaN)
-also_infinity: (inf)
-also_minus_inf: (-inf)
-not_a_number: (NaN)
-bool_true: true
-bool_false: false
-null_value: 
-shorthand_null: 
-empty_value: 
-regular_list:
-  - first item
-  - second item
-  - third item
-shorthand_list:
-  - first item
-  - second item
-  - third item
-shorthand_quoted_list:
-  - one
-  - two
-  - three
-empty_shorthand_list: []
-map:
-  one: first
-  two: second
-shorthand_map:
-  one: first
-  two: second
-  third: this, the thing
-nested_map_lists:
-  -
-    name: Bill
-    job: Architect
-  -
-    name: Fred
-    job: Designer
-  -
-    name: Willie
-    job: Builder
-nested_shorthand_maps:
-  -
-    name: Bill
-    job: Architect
-  -
-    name: Fred
-    job: Designer
-  -
-    name: Willie
-    job: Builder
-nested_maps:
-  first:
-    name: Bill
-    job: Architect
-  second:
-    name: Fred
-    job: Designer
-  third:
-    name: Willie
-    job: Builder
-deep_nest_list_shortcut:
-  first:
-    second:
-      third:
-        fourth:
-          fifth:
-            - one
-            - two
-sample_test:
-  -
-    name: name
-    label: Name
-    type: text
-    validate:
-      required: true
-EXPECTED;
+		$expected = file_get_contents(__DIR__.'/TestData/make-result.yaml');
 
 		$this->assertEquals($expected, $yaml);
 	}
-	
+
 	public function testStrings()
 	{
 		$this->assertEquals('this is a string', $this->parsed['string']);
@@ -365,13 +53,13 @@ EXPECTED;
 		$this->assertSame('false', $this->parsed['quoted_false']);
 		$this->assertEquals('http://something.com', $this->parsed['url']);
 	}
-	
+
 	public function testScalars()
 	{
 		$this->assertEquals("This is a scalar\nthat will preserve\nits line breaks.", $this->parsed['literal_scalar']);
 		$this->assertEquals("This is a scalar that will fold up line breaks.", $this->parsed['folding_scalar']);
 	}
-	
+
 	public function testNumbers()
 	{
 		$this->assertSame(42, $this->parsed['integer']);
@@ -386,7 +74,7 @@ EXPECTED;
 		$this->assertTrue(is_nan($this->parsed['not_a_number']));
 		$this->assertTrue(is_nan($this->parsed['also_nan']));
 	}
-	
+
 	public function testBooleans()
 	{
 		$this->assertSame(true, $this->parsed['bool_true']);
@@ -395,20 +83,20 @@ EXPECTED;
 		$this->assertSame(null, $this->parsed['shorthand_null']);
 		$this->assertSame(null, $this->parsed['empty_value']);
 	}
-	
+
 	public function testLists()
 	{
 		$this->assertCount(3, $this->parsed['regular_list']);
 		$this->assertCount(3, $this->parsed['shorthand_list']);
 		$this->assertInternalType('array', $this->parsed['empty_shorthand_list']);
 	}
-	
+
 	public function testMaps()
 	{
 		$this->assertCount(2, $this->parsed['map']);
 		$this->assertCount(3, $this->parsed['shorthand_map']);
 	}
-	
+
 	public function testComplexStructures()
 	{
 		$this->assertCount(3, $this->parsed['nested_map_lists']);
@@ -422,8 +110,67 @@ EXPECTED;
 		$this->assertCount(3, $this->parsed['nested_maps']);
 		$this->assertEquals('Fred', $this->parsed['nested_maps']['second']['name']);
 		$this->assertEquals('Builder', $this->parsed['nested_maps']['third']['job']);
-		
+
 		$this->assertCount(2, $this->parsed['deep_nest_list_shortcut']['first']['second']['third']['fourth']['fifth']);
 		$this->assertEquals('two', $this->parsed['deep_nest_list_shortcut']['first']['second']['third']['fourth']['fifth'][1]);
+	}
+
+	public function testArrayToMap()
+	{
+		$map = array(
+			'one' => 'first',
+			'two' => 'second'
+		);
+		$this->assertEquals(
+			"---\n".
+			"one: first\n".
+			"two: second",
+			\secondparty\Dipper\Dipper::make($map)
+		);
+	}
+
+	public function testNestedArrayToMap()
+	{
+		$map = array(
+			'nested' => array(
+				'one' => 'first',
+				'two' => 'second'
+			)
+		);
+		$this->assertEquals(
+			"---\n".
+			"nested:\n".
+			"  one: first\n".
+			"  two: second",
+			\secondparty\Dipper\Dipper::make($map)
+		);
+	}
+
+	public function testObjectToMap()
+	{
+		$map = new stdClass();
+		$map->one = 'first';
+		$map->two = 'second';
+		$this->assertEquals(
+			"---\n".
+			"one: first\n".
+			"two: second",
+			\secondparty\Dipper\Dipper::make($map)
+		);
+	}
+
+	public function testNestedObjectToMap()
+	{
+		$map = new stdClass();
+		$map->nested = new stdClass();
+		$map->nested->one = 'first';
+		$map->nested->two = 'second';
+		$this->assertEquals(
+			"---\n".
+			"nested:\n".
+			"  one: first\n".
+			"  two: second",
+			\secondparty\Dipper\Dipper::make($map)
+		);
 	}
 }

--- a/tests/TestData/example-crlf.yaml
+++ b/tests/TestData/example-crlf.yaml
@@ -1,0 +1,101 @@
+working: true
+
+string: this is a string
+single_quoted_string: 'this is a single-quoted string'
+double_quoted_string: "this is a double-quoted string"
+non_full_quoted_string: "\"This is\" some text in a string"
+string_with_single_quote: this's a string with a single quote
+string_with_colon: 'this is a string: containing a colon'
+string_with_comma: F j, Y
+quoted_number: "120"
+quoted_true: "true"
+quoted_false: "false"
+url: http://something.com
+
+literal_scalar: |
+  This is a scalar
+  that will preserve
+  its line breaks.
+
+folding_scalar: >
+  This is a scalar
+  that will fold up
+  line breaks.
+
+literal_scalar_with_markdown: |
+  ### Testing
+  This should be OK and not a comment
+
+  ### Another
+  Testing again
+
+integer: 42            # becomes an integer
+float: -12.12          # becomes a float
+octal: 0755            # YAML 1.0-style, becomes an integer, converted from octal
+also_octal: 0o755      # YAML 1.2-style, becomes an integer, converted from octal
+hex: 0xff              # becomes an integer, converted from hexadecimal
+infinite: (inf)        # YAML 1.0-style, becomes INF, PHP constant for infinity
+minus_inf: (-inf)      # YAML 1.0-style, becomes -INF, PHP constant for negative infinity
+also_nan: (NaN)        # YAML 1.0-style, becomes NAN, PHP constant for not-a-number
+also_infinity: .inf    # YAML 1.2-style, becomes INF, PHP constant for infinity
+also_minus_inf: -.inf  # YAML 1.2-style, becomes -INF, PHP constant for negative infinity
+not_a_number: .NaN     # YAML 1.2-style, becomes NAN, PHP constant for not-a-number
+
+bool_true: true        # becomes true (as a boolean)
+bool_false: false      # becomes false (as a boolean)
+null_value: null       # becomes a PHP null value
+shorthand_null: ~      # becomes a PHP null value
+empty_value:           # becomes a PHP null value
+
+regular_list:
+  - first item
+  - second item
+  - third item
+
+shorthand_list: [ first item, second item, third item ]
+shorthand_quoted_list: [ 'one', 'two', 'three' ]
+empty_shorthand_list: []
+
+map:
+  one: first
+  two: second
+
+shorthand_map: { one: first, two: second, third: "this, the thing" }
+
+nested_map_lists:
+  - name: Bill
+    job: Architect
+  - name: Fred
+    job: Designer
+  - name: Willie
+    job: Builder
+
+nested_shorthand_maps:
+  - { name: Bill, job: Architect }
+  - { name: Fred, job: Designer }
+  - { name: Willie, job: Builder }
+
+nested_maps:
+  first:
+    name: Bill
+    job: Architect
+  second:
+    name: Fred
+    job: Designer
+  third:
+    name: Willie
+    job: Builder
+
+deep_nest_list_shortcut:
+  first:
+    second:
+      third:
+        fourth:
+          fifth: [ one, two ]
+
+sample_test:
+  - name: name
+    label: Name
+    type: text
+    validate:
+      required: true

--- a/tests/TestData/example-lf.yaml
+++ b/tests/TestData/example-lf.yaml
@@ -1,0 +1,101 @@
+working: true
+
+string: this is a string
+single_quoted_string: 'this is a single-quoted string'
+double_quoted_string: "this is a double-quoted string"
+non_full_quoted_string: "\"This is\" some text in a string"
+string_with_single_quote: this's a string with a single quote
+string_with_colon: 'this is a string: containing a colon'
+string_with_comma: F j, Y
+quoted_number: "120"
+quoted_true: "true"
+quoted_false: "false"
+url: http://something.com
+
+literal_scalar: |
+  This is a scalar
+  that will preserve
+  its line breaks.
+
+folding_scalar: >
+  This is a scalar
+  that will fold up
+  line breaks.
+
+literal_scalar_with_markdown: |
+  ### Testing
+  This should be OK and not a comment
+
+  ### Another
+  Testing again
+
+integer: 42            # becomes an integer
+float: -12.12          # becomes a float
+octal: 0755            # YAML 1.0-style, becomes an integer, converted from octal
+also_octal: 0o755      # YAML 1.2-style, becomes an integer, converted from octal
+hex: 0xff              # becomes an integer, converted from hexadecimal
+infinite: (inf)        # YAML 1.0-style, becomes INF, PHP constant for infinity
+minus_inf: (-inf)      # YAML 1.0-style, becomes -INF, PHP constant for negative infinity
+also_nan: (NaN)        # YAML 1.0-style, becomes NAN, PHP constant for not-a-number
+also_infinity: .inf    # YAML 1.2-style, becomes INF, PHP constant for infinity
+also_minus_inf: -.inf  # YAML 1.2-style, becomes -INF, PHP constant for negative infinity
+not_a_number: .NaN     # YAML 1.2-style, becomes NAN, PHP constant for not-a-number
+
+bool_true: true        # becomes true (as a boolean)
+bool_false: false      # becomes false (as a boolean)
+null_value: null       # becomes a PHP null value
+shorthand_null: ~      # becomes a PHP null value
+empty_value:           # becomes a PHP null value
+
+regular_list:
+  - first item
+  - second item
+  - third item
+
+shorthand_list: [ first item, second item, third item ]
+shorthand_quoted_list: [ 'one', 'two', 'three' ]
+empty_shorthand_list: []
+
+map:
+  one: first
+  two: second
+
+shorthand_map: { one: first, two: second, third: "this, the thing" }
+
+nested_map_lists:
+  - name: Bill
+    job: Architect
+  - name: Fred
+    job: Designer
+  - name: Willie
+    job: Builder
+
+nested_shorthand_maps:
+  - { name: Bill, job: Architect }
+  - { name: Fred, job: Designer }
+  - { name: Willie, job: Builder }
+
+nested_maps:
+  first:
+    name: Bill
+    job: Architect
+  second:
+    name: Fred
+    job: Designer
+  third:
+    name: Willie
+    job: Builder
+
+deep_nest_list_shortcut:
+  first:
+    second:
+      third:
+        fourth:
+          fifth: [ one, two ]
+
+sample_test:
+  - name: name
+    label: Name
+    type: text
+    validate:
+      required: true

--- a/tests/TestData/make-result.yaml
+++ b/tests/TestData/make-result.yaml
@@ -1,0 +1,105 @@
+---
+working: true
+string: this is a string
+single_quoted_string: this is a single-quoted string
+double_quoted_string: this is a double-quoted string
+non_full_quoted_string: "\"This is\" some text in a string"
+string_with_single_quote: this's a string with a single quote
+string_with_colon: 'this is a string: containing a colon'
+string_with_comma: F j, Y
+quoted_number: '120'
+quoted_true: 'true'
+quoted_false: 'false'
+url: 'http://something.com'
+literal_scalar: |
+  This is a scalar
+  that will preserve
+  its line breaks.
+folding_scalar: This is a scalar that will fold up line breaks.
+literal_scalar_with_markdown: |
+  ### Testing
+  This should be OK and not a comment
+    
+  ### Another
+  Testing again
+integer: 42
+float: -12.12
+octal: 493
+also_octal: 493
+hex: 255
+infinite: (inf)
+minus_inf: (-inf)
+also_nan: (NaN)
+also_infinity: (inf)
+also_minus_inf: (-inf)
+not_a_number: (NaN)
+bool_true: true
+bool_false: false
+null_value: 
+shorthand_null: 
+empty_value: 
+regular_list:
+  - first item
+  - second item
+  - third item
+shorthand_list:
+  - first item
+  - second item
+  - third item
+shorthand_quoted_list:
+  - one
+  - two
+  - three
+empty_shorthand_list: []
+map:
+  one: first
+  two: second
+shorthand_map:
+  one: first
+  two: second
+  third: this, the thing
+nested_map_lists:
+  -
+    name: Bill
+    job: Architect
+  -
+    name: Fred
+    job: Designer
+  -
+    name: Willie
+    job: Builder
+nested_shorthand_maps:
+  -
+    name: Bill
+    job: Architect
+  -
+    name: Fred
+    job: Designer
+  -
+    name: Willie
+    job: Builder
+nested_maps:
+  first:
+    name: Bill
+    job: Architect
+  second:
+    name: Fred
+    job: Designer
+  third:
+    name: Willie
+    job: Builder
+deep_nest_list_shortcut:
+  first:
+    second:
+      third:
+        fourth:
+          fifth:
+            - one
+            - two
+sample_test:
+  -
+    name: name
+    label: Name
+    type: text
+    validate:
+      required: true


### PR DESCRIPTION
Refactor tests to avoid mixing indentation and line break styles in test file. This allows the IDE to do formatting.

Add serialization support for `stdClass`, `json_decode()` will provide `stdClass` objects without an specific option. They can be cast into an array (and to not implement `__toString()`).