### PR TITLE
Add parseFile method to parse YAML files drectly

### DIFF
--- a/Dipper.php
+++ b/Dipper.php
@@ -116,6 +116,32 @@ class Dipper
 	}
 
 
+    /**
+     * Takes a given file name and parses its content for YAML
+     *
+     * @param string  $file  The YAML file to parse
+     * @return array
+     * @throw \Exception
+     */
+    public static function parseFile($file)
+    {
+        if (!file_exists($file)) {
+            throw new \Exception('Missing file \''.$file.'\'!', 1);
+        }
+
+        $php = self::parse(file_get_contents($file));
+
+        if (empty($php)) {
+            throw new \Exception('\''.$file.'\' is empty!', 2);
+        }
+
+        if (!is_array($php)) {
+            throw new \Exception('Invalid file \''.$conf_file.'\'!', 3);
+        }
+
+        return $php;
+    }
+
 	/**
 	 * Makes YAML from PHP
 	 *


### PR DESCRIPTION
Extend with `parseFile($file)`

Checks for
- File exists
- File is not empty
- Parsed result is an array

Throws Exception otherwise.